### PR TITLE
👷🐙 Don't list upgrade actions in the release draft

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     commit-message: {prefix: ⬆️}
     labels:
       - 🤖 Robot
+      - 🥷 Stealth
       - 🧹 Upkeep
 
   # NB: a custom dependency upgrade workflow is under workflows/upgrade.yml

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -72,6 +72,7 @@ jobs:
             --title "⬆️ Upgrade dependencies" \
             --body "Remember to check that the CI action passed!" \
             --label "🤖 Robot" \
+            --label "🥷 Stealth" \
             --label "🧹 Upkeep" \
             | true
           gh workflow run ci.yml --ref $UPGRADE_BRANCH


### PR DESCRIPTION
these upgrades can happen daily so no sense to list them individually in the release notes