### PR TITLE
♻️🎨 Turn string types to literal type annotations

### DIFF
--- a/magic/console/config.py
+++ b/magic/console/config.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import string
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from magic.utils.errors import (
     BadProjectRootError,
@@ -10,9 +11,6 @@ from magic.utils.errors import (
     NotAllowedError,
     NotLowAsciiError,
 )
-
-if TYPE_CHECKING:
-    from typing import List
 
 
 class Config(Namespace):
@@ -41,7 +39,7 @@ class Config(Namespace):
             raise BadProjectRootError
 
 
-def parse_config(arguments: "List[str]") -> Config:
+def parse_config(arguments: list[str]) -> Config:
     parser = ArgumentParser()
     parser.add_argument("--name", help="package name")
     parser.add_argument("--author", help="package author name")

--- a/magic/console/core.py
+++ b/magic/console/core.py
@@ -1,9 +1,7 @@
+from __future__ import annotations
+
 import shutil
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import List
 
 from magic.console.config import parse_config
 from magic.utils.files import (
@@ -23,7 +21,7 @@ def main() -> ErrorCode:
         return 1
 
 
-def run(arguments: "List[str]") -> ErrorCode:
+def run(arguments: list[str]) -> ErrorCode:
     config = parse_config(arguments[1:])
 
     rename_package(config)
@@ -61,6 +59,6 @@ def run(arguments: "List[str]") -> ErrorCode:
     return 0
 
 
-def write_out(messages: "List[str]") -> None:
+def write_out(messages: list[str]) -> None:
     for message in messages:
         sys.stdout.write(f"{message}\n")

--- a/magic/utils/errors.py
+++ b/magic/utils/errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import string
 
 

--- a/magic/utils/files.py
+++ b/magic/utils/files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 from pathlib import Path
 from string import Template
@@ -9,7 +11,7 @@ if TYPE_CHECKING:
     from magic.console.config import Config
 
 
-def rename_package(config: "Config") -> None:
+def rename_package(config: Config) -> None:
     package_dir = config.genvi_root / DEFAULT_PACKAGE_NAME
     test_dir = config.genvi_root / "tests"
     github_dir = config.genvi_root / ".github"
@@ -40,7 +42,7 @@ def rename_package(config: "Config") -> None:
     )
 
 
-def generate_readme(config: "Config") -> str:
+def generate_readme(config: Config) -> str:
     substitutes = {
         "name": config.name,
     }

--- a/myproject/animals/animal.py
+++ b/myproject/animals/animal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import logging
 

--- a/myproject/animals/blue_whale.py
+++ b/myproject/animals/blue_whale.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from myproject.animals.animal import Animal

--- a/myproject/animals/common_viper.py
+++ b/myproject/animals/common_viper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from myproject.animals.animal import Animal

--- a/myproject/animals/human.py
+++ b/myproject/animals/human.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from myproject.animals.animal import Animal

--- a/myproject/console/core.py
+++ b/myproject/console/core.py
@@ -1,13 +1,11 @@
+from __future__ import annotations
+
 import logging
 import os
-from typing import TYPE_CHECKING
 
 import click
 
 from myproject.console.reporting import setup_console_logging
-
-if TYPE_CHECKING:
-    from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -36,9 +34,7 @@ log = logging.getLogger(__name__)
     flag_value=logging.getLevelName(logging.ERROR),
     help="Turn on quiet quirks mode, only showing errors and up.",
 )
-def cli(
-    log_level: "Optional[str]",
-) -> None:
+def cli(log_level: str | None) -> None:
     """
     Show debug information.
 

--- a/myproject/console/reporting.py
+++ b/myproject/console/reporting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 from typing import TYPE_CHECKING, ClassVar
@@ -13,7 +15,7 @@ class ColorFormatter(logging.Formatter):  # pragma: no cover
     _bold_red = "\x1b[31;1m"
     _reset = "\x1b[0m"
     _msg_format = "%(message)s"
-    _formats: ClassVar["Mapping[int, str]"] = {
+    _formats: ClassVar[Mapping[int, str]] = {
         logging.CRITICAL: _bold_red + _msg_format + _reset,
         logging.ERROR: _red + _msg_format + _reset,
         logging.WARNING: _yellow + _msg_format + _reset,

--- a/tests/magic/conftest.py
+++ b/tests/magic/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture()
-def tmp_genvi_path(tmp_path: "Path") -> "Path":
+def tmp_genvi_path(tmp_path: Path) -> Path:
     # Create a mini version of what `genvi` directory looks like.
 
     (tmp_path / "Makefile").write_text(

--- a/tests/magic/console/test_config.py
+++ b/tests/magic/console/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/magic/console/test_core.py
+++ b/tests/magic/console/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -23,8 +25,8 @@ VALID_ARGV = [
 
 @pytest.fixture(autouse=True)
 def _patch_resolve_genvi_root(
-    mocker: "MockFixture",
-    tmp_genvi_path: "Path",
+    mocker: MockFixture,
+    tmp_genvi_path: Path,
 ) -> None:
     # also effectively initializes the `tmp_genvi_path` for all tests in this module
     target = "magic.console.config.resolve_genvi_root"
@@ -32,8 +34,8 @@ def _patch_resolve_genvi_root(
 
 
 def test_main(
-    mocker: "MockFixture",
-    capsys: "CaptureFixture[str]",
+    mocker: MockFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     mocker.patch("sys.argv", VALID_ARGV)
     assert main() == 0
@@ -43,8 +45,8 @@ def test_main(
 
 
 def test_main_no_arguments(
-    mocker: "MockFixture",
-    capsys: "CaptureFixture[str]",
+    mocker: MockFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     mocker.patch("builtins.input").return_value = ""
     mocker.patch("sys.argv", ["/mock/executable"])
@@ -55,8 +57,8 @@ def test_main_no_arguments(
 
 
 def test_main_not_interactive(
-    mocker: "MockFixture",
-    capsys: "CaptureFixture[str]",
+    mocker: MockFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     mocker.patch("builtins.input").side_effect = EOFError
     mocker.patch("sys.argv", ["/mock/executable"])
@@ -67,9 +69,9 @@ def test_main_not_interactive(
 
 
 def test_main_internal_error(
-    mocker: "MockFixture",
-    capsys: "CaptureFixture[str]",
-    tmp_genvi_path: "Path",
+    mocker: MockFixture,
+    capsys: CaptureFixture[str],
+    tmp_genvi_path: Path,
 ) -> None:
     (tmp_genvi_path / "Makefile").unlink()
     mocker.patch("sys.argv", VALID_ARGV)

--- a/tests/magic/utils/test_files.py
+++ b/tests/magic/utils/test_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -17,7 +19,7 @@ if TYPE_CHECKING:
     ("author", "email"),
     [("", ""), ("Barry Bananas", "barry@example.com")],
 )
-def test_renaming_package(tmp_genvi_path: "Path", author: str, email: str) -> None:
+def test_renaming_package(tmp_genvi_path: Path, author: str, email: str) -> None:
     config = Config(
         name="monkey",
         author=author,
@@ -27,7 +29,7 @@ def test_renaming_package(tmp_genvi_path: "Path", author: str, email: str) -> No
     rename_package(config)
 
 
-def test_generating_readme(tmp_genvi_path: "Path") -> None:
+def test_generating_readme(tmp_genvi_path: Path) -> None:
     config = Config(
         name="monkey",
         author="",
@@ -39,7 +41,7 @@ def test_generating_readme(tmp_genvi_path: "Path") -> None:
     assert "$$name" not in readme_contents
 
 
-def test_stripping_files(tmp_path: "Path") -> None:
+def test_stripping_files(tmp_path: Path) -> None:
     test_file = tmp_path / "my_file"
     test_file.write_text(
         (

--- a/tests/myproject/console/test_core.py
+++ b/tests/myproject/console/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 
@@ -7,8 +9,6 @@ from click.testing import CliRunner
 from myproject.console.core import cli
 
 if TYPE_CHECKING:
-    from typing import List
-
     from _pytest.capture import CaptureFixture
     from _pytest.logging import LogCaptureFixture
     from pytest_mock import MockFixture
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
     ],
 )
 def test_main_log_levels(
-    capsys: "CaptureFixture[str]",
-    caplog: "LogCaptureFixture",
-    args: "List[str]",
+    capsys: CaptureFixture[str],
+    caplog: LogCaptureFixture,
+    args: list[str],
     log_level: str,
 ) -> None:
     runner = CliRunner()
@@ -45,7 +45,7 @@ def test_main_log_levels(
     assert not std.err
 
 
-def test_main_logging_setup_fails(mocker: "MockFixture") -> None:
+def test_main_logging_setup_fails(mocker: MockFixture) -> None:
     error_message = "boom things went wrong"
     error_source = "myproject.console.core.setup_console_logging"
     mocker.patch(error_source).side_effect = Exception(error_message)

--- a/tools/bump/core.py
+++ b/tools/bump/core.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import re
 from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Tuple
 
 
 # Tools for managing project semantic version numbering.
@@ -18,7 +19,7 @@ class SemanticPart(Enum):
     PATCH = "patch"
 
 
-def bump(version_file: "Path", bump_by: SemanticPart) -> None:
+def bump(version_file: Path, bump_by: SemanticPart) -> None:
     with version_file.open(encoding="utf-8") as file:
         content = file.read()
     content = bump_line(content, bump_by)
@@ -38,7 +39,7 @@ def bump_version(
     minor: int,
     patch: int,
     bump_by: SemanticPart,
-) -> "Tuple[int, int, int]":
+) -> tuple[int, int, int]:
     if bump_by == SemanticPart.PATCH:
         patch += 1
     if bump_by == SemanticPart.MINOR:

--- a/tools/bump/tests/test_core.py
+++ b/tools/bump/tests/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 from pathlib import Path
 

--- a/tools/freezenuts/core.py
+++ b/tools/freezenuts/core.py
@@ -9,6 +9,8 @@ Usage:
 
 """
 
+from __future__ import annotations
+
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -18,10 +20,9 @@ from packaging.version import Version
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import List
 
 
-def package_versions(project_name: str) -> "List[Version]":
+def package_versions(project_name: str) -> list[Version]:
     """Get package version history from PyPI using `pip`."""
     # possibly switch to `distlib`, raw requests or something else later
     # https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program
@@ -56,7 +57,7 @@ def get_oldest_matching_requirement(requirement: Requirement) -> Requirement:
     return Requirement(f"{requirement.name}{extras}=={candidates[0]}")
 
 
-def get_oldest_requirements(requirements_file: "Path") -> "List[Requirement]":
+def get_oldest_requirements(requirements_file: Path) -> list[Requirement]:
     with requirements_file.open(encoding="utf-8") as file:
         lines = file.readlines()
     lines = [line.partition("#")[0].rstrip(" \n") for line in lines]
@@ -66,6 +67,6 @@ def get_oldest_requirements(requirements_file: "Path") -> "List[Requirement]":
 
 
 class PackageNotFoundError(RuntimeError):
-    def __init__(self, requirement: Requirement, candidates: "List[Version]") -> None:
+    def __init__(self, requirement: Requirement, candidates: list[Version]) -> None:
         as_strings = ", ".join([str(c) for c in candidates])
         super().__init__(f"No valid candidate found for {requirement} in: {as_strings}")

--- a/tools/freezenuts/tests/test_core.py
+++ b/tools/freezenuts/tests/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,8 +16,6 @@ from tools.freezenuts.core import (
 )
 
 if TYPE_CHECKING:
-    from typing import List, Optional
-
     from pytest_mock import MockFixture
 
 REQUIREMENTS_CONTENT = """
@@ -29,13 +29,13 @@ balthazar>=1.24,<1.28  # not
 
 
 class CheckOutputMock(Protocol):
-    def __call__(self, output: "Optional[str]") -> None:
+    def __call__(self, output: str | None) -> None:
         ...
 
 
 @pytest.fixture(name="check_output_mock")
-def check_output_mocker(mocker: "MockFixture") -> CheckOutputMock:
-    def setup_check_output_mocker(output: "Optional[str]" = None) -> None:
+def check_output_mocker(mocker: MockFixture) -> CheckOutputMock:
+    def setup_check_output_mocker(output: str | None = None) -> None:
         if output is not None:
             mocker.patch("subprocess.check_output").return_value = output.encode()
 
@@ -131,7 +131,7 @@ def test_requirement_deep_freezing(
 )
 def test_querying_package_versions(
     output: str,
-    expected: "List[str]",
+    expected: list[str],
     check_output_mock: CheckOutputMock,
 ) -> None:
     check_output_mock(output)


### PR DESCRIPTION
The `__future__` import is required for Python versions prior 3.9