### PR TITLE
⬆️ Upgrade dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,11 +32,11 @@ repos:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: '1.14.0'
+    rev: '1.15.0'
     hooks:
       - id: blacken-docs
         additional_dependencies: [
-          'black==23.1.0',
+          'black==23.3.0',
         ]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ cryptography==41.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
-editables==0.3
+editables==0.4
     # via hatchling
 exceptiongroup==1.1.2
     # via
@@ -34,7 +34,7 @@ h11==0.14.0
     # via httpcore
 hatch==1.7.0
     # via -r requirements-dev.in
-hatchling==1.17.1
+hatchling==1.18.0
     # via hatch
 httpcore==0.17.3
     # via httpx
@@ -52,18 +52,11 @@ idna==3.4
 importlib-metadata==4.2.0
     # via
     #   -r requirements.txt
-    #   build
-    #   click
-    #   hatchling
     #   keyring
-    #   pluggy
-    #   pre-commit
-    #   pytest
     #   pytest-randomly
-    #   virtualenv
 iniconfig==2.0.0
     # via pytest
-jaraco-classes==3.2.3
+jaraco-classes==3.3.0
     # via keyring
 jeepney==0.8.0
     # via
@@ -71,7 +64,7 @@ jeepney==0.8.0
     #   secretstorage
 keyring==23.9.3
     # via hatch
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
@@ -104,7 +97,7 @@ pluggy==1.2.0
     # via
     #   hatchling
     #   pytest
-pre-commit==2.21.0
+pre-commit==3.3.3
     # via -r requirements-dev.in
 ptyprocess==0.7.0
     # via pexpect
@@ -126,7 +119,7 @@ pytest-cov==4.1.0
     # via -r requirements-dev.in
 pytest-mock==3.11.1
     # via -r requirements-dev.in
-pytest-randomly==3.12.0
+pytest-randomly==3.13.0
     # via -r requirements-dev.in
 pyyaml==6.0
     # via pre-commit
@@ -156,19 +149,12 @@ tomli-w==1.0.0
     # via hatch
 tomlkit==0.11.8
     # via hatch
-trove-classifiers==2023.5.24
+trove-classifiers==2023.7.6
     # via hatchling
-typed-ast==1.5.5
-    # via mypy
 typing-extensions==4.7.1
     # via
     #   -r requirements.txt
-    #   anyio
-    #   h11
-    #   importlib-metadata
-    #   markdown-it-py
     #   mypy
-    #   platformdirs
     #   rich
 userpath==1.8.0
     # via hatch
@@ -179,7 +165,7 @@ virtualenv==20.16.2
     #   pre-commit
 wheel==0.40.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.16.0
     # via
     #   -r requirements.txt
     #   importlib-metadata

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,8 @@
 # e.g. use `requests>2` instead of `requests` if you don't want to get `requests==0.2.0`
 # from 2011.
 typing_extensions>=4.3,<5
-click>=8
+click>=8,<8.1.4
     # `black` used in development requires >=8.0.0
+    # 8.1.4 breaks `mypy` type checks: https://github.com/pallets/click/issues/2558
 importlib-metadata>=3.6.0,<4.3
     # lower bound from `keyring`, `flake8` doesn't accept any newer one... both from dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,8 @@
 click==8.1.3
     # via -r requirements.in
 importlib-metadata==4.2.0
-    # via
-    #   -r requirements.in
-    #   click
+    # via -r requirements.in
 typing-extensions==4.7.1
-    # via
-    #   -r requirements.in
-    #   importlib-metadata
-zipp==3.15.0
+    # via -r requirements.in
+zipp==3.16.0
     # via importlib-metadata


### PR DESCRIPTION
Also pins `click` as it breaks `mypy` type checks: https://github.com/pallets/click/issues/2558